### PR TITLE
Increase ranges for bytestring and base. Fix warnings re: pure/return.

### DIFF
--- a/bzlib.cabal
+++ b/bzlib.cabal
@@ -1,5 +1,5 @@
 name:            bzlib
-version:         0.5.1.0
+version:         0.6.0.0
 copyright:       (c) 2006-2015 Duncan Coutts
 license:         BSD3
 license-file:    LICENSE
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type: git
   location: https://github.com/hackage-trustees/bzlib.git
-  tag: 0.5.1.0
+  tag: 0.6.0.0
 
 library
   default-language: Haskell2010
@@ -38,8 +38,8 @@ library
                    Codec.Compression.BZip.Internal
   other-modules:   Codec.Compression.BZip.Stream
   default-extensions: CPP, ForeignFunctionInterface
-  build-depends:   base >= 4.3 && < 4.16,
-                   bytestring == 0.9.* || == 0.10.*
+  build-depends:   base >= 4.3 && < 5,
+                   bytestring >= 0.9.0 && < 0.12
   if !impl(ghc >=8.0)
     build-depends: fail ==4.9.*
   includes:        bzlib.h


### PR DESCRIPTION
This PR makes it so bzlib is compilable with both GHC 9.2 and 9.4. It also cleans up some warnings related to Applicative being a superclass of Monad. 

Assuming the code changes are ok I need a little bit of guidance on the version number, however. I mainly increased the major version number out of an abundance of caution, but can change it to be a minor version bump if reviewers think that's appropriate.